### PR TITLE
Python scripts for interacting with RedCap via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# config files
+*config.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# redcap
+Scripts for interacting with RedCap via API
+
+
+## upload_csv_to_redcap.py [options] pid input_filename
+
+Read CSV file or stdin made to be loaded into redcap via the import tool and update project using API.
+
+    Options:
+        -k, --key key_name Primary key for RedCap study, default is record_id
+        -c, --chunk chunk_size Number of records to upload in one POST request, default is 100
+        -v, --verbose Turn on verbose logging
+    e.g. 
+        python upload_csv_to_redcap.py -k project_id -c 10 -v 99 redcap.csv
+        python make_an_impact.py | python upload_csv_to_redcap.py -c 100 99
+
+## redcap.py
+
+    import redcap
+
+    redcap.update_records(pid, list_of_fields_to_values, overwrite, return_content, verbose)
+
+Updates any fields for a record included in the list_of_fields_to_values dictionary.  list_of_fields_to_values is a list of dictionaries, each dictionary containing the fields and their values for that item in the list.  Overwrite is turned ON by default, so blank values will overwrite any value stored in RedCap.  The record id MUST be included.  redcap_repeat_instrument and redcap_repeat_instance are required for repeat instruments.  All dates must be in Y-M-D format regardless of the format definition for the field.

--- a/redcap.py
+++ b/redcap.py
@@ -1,0 +1,39 @@
+# API
+import pycurl, cStringIO
+import redcap_config
+import json
+from StringIO import StringIO
+import sys
+
+def update_records(pid, list_of_fields_to_values, overwrite="overwrite", return_content="count", verbose=False):
+  """Updates any fields for a record included in the fields_to_values dictionary.  
+    list_of_fields_to_values is a list of dictionaries, each dictionary
+    containing the fields and their values for that item in the list.
+    Overwrite is turned ON, so blank values will overwrite any value stored in RedCap.  
+    The record id MUST be included.  redcap_repeat_instrument and redcap_repeat_instance
+    are required for repeat instruments.  All dates must be in Y-M-D format regardless
+    of the format definition for the field."""
+  buf = cStringIO.StringIO()
+  json_data = '[' + ",".join([ '{' + ",".join(["\"%s\":\"%s\"" % (field, str(value).replace("\"", "\\\"")) for field, value in fields_to_values.iteritems()]) + '}' for fields_to_values in list_of_fields_to_values ]) + ']'
+  print "LOG:", json_data
+  data = {
+    'token': redcap_config.pids_to_tokens[pid],
+    'content': 'record',
+    'format': 'json',
+    'type': 'flat',
+    'overwriteBehavior': 'overwrite',
+    'data': json_data,
+    'returnContent': return_content,
+    'returnFormat': 'json',
+  }
+  curl = pycurl.Curl()
+  curl.setopt(curl.URL, redcap_config.api_url)
+  curl.setopt(curl.HTTPPOST, data.items())
+  curl.setopt(curl.WRITEFUNCTION, buf.write)
+  #curl.setopt(pycurl.SSL_VERIFYPEER, 0)
+  #curl.setopt(pycurl.SSL_VERIFYHOST, 0)
+  curl.perform()
+  curl.close()
+  body = buf.getvalue()
+  buf.close()
+  return json.load(StringIO(body)) # returns count of updated records e.g. {"count": 1} or list of IDs that were updated

--- a/upload_csv_to_redcap.py
+++ b/upload_csv_to_redcap.py
@@ -1,0 +1,114 @@
+# Read CSV file made to be loaded into redcap via the import tool and update project using API
+#
+# Usage:
+#   upload_csv_to_redcap.py [options] pid input_filename
+#     Options:
+#       -k, --key key_name Primary key for RedCap study, default is record_id
+#       -c, --chunk chunk_size Number of records to upload in one POST request, default is 100
+#       -v, --verbose Turn on verbose logging
+#   e.g. upload_csv_to_redcap.py -k project_id -c 10 -v 99 redcap.csv
+#
+# Author: Manda Wilson
+
+import redcap
+import redcap_config
+import csv
+import sys
+import os.path
+import getopt
+
+DEFAULT_CHUNK = 100
+DEFAULT_PRIMARY_KEY = "record_id"
+
+def update_redcap(expected_ids, pid, current_rows, overwrite="normal", return_content="ids", verbose=False):
+  updated = redcap.update_records(pid, current_rows, overwrite="normal", return_content="ids", verbose=verbose)
+  if verbose:
+    print "LOG: updated:", updated
+  if "error" in updated:
+    print >> sys.stderr, "ERROR: failed to update record(s).  Message is '%s'.  JSON is '%s'" % (updated["error"], row)
+    print >> sys.stderr, [row]
+    sys.exit()
+
+  failed_to_update = expected_ids - set(updated)
+  if failed_to_update: 
+    print >> sys.stderr, "ERROR: failed to update record(s): '%s'" % (",".join(failed_to_update))
+
+def parse_csv(pid, input_stream, primary_key, chunk, verbose=False):
+  csvreader = csv.DictReader(input_stream, delimiter=',', quotechar='"')
+  current_rows = []
+  expected_ids = set([])
+  for row in csvreader:
+    expected_ids.add(row[primary_key])
+    current_rows.append(row)
+    if len(current_rows) == chunk:
+      update_redcap(expected_ids, pid, current_rows, overwrite="normal", return_content="ids", verbose=verbose)
+      current_rows = [] # reset for next batch  
+      expected_ids = set([])
+
+  if len(current_rows) > 0:
+    update_redcap(expected_ids, pid, current_rows, overwrite="normal", return_content="ids", verbose=verbose)
+
+
+def usage():
+  print "Usage:"
+  print "  upload_csv_to_redcap.py [options] pid input_filename"
+  print "    Options:"
+  print "      -k, --key key_name Primary key for RedCap study, default is record_id"
+  print "      -c, --chunk chunk_size Number of records to upload in one POST request, default is", DEFAULT_CHUNK
+  print "      -v, --verbose Turn on verbose logging"
+  print "  e.g. upload_csv_to_redcap.py -k project_id -c 10 -v 99 redcap.csv"
+  
+
+try:
+  opts, args = getopt.getopt(sys.argv[1:], "k:c:v", ["key=", "chunk=", "verbose"])
+except getopt.GetoptError as err:
+  # print help information and exit:
+  print str(err) # will print something like "option -a not recognized"
+  usage()
+  sys.exit(1)
+
+if args < 1:
+  print >> sys.stderr, "ERROR: project id is required"
+  usage()
+  sys.exit(1)
+
+pid = args[0]
+input_filename = args[1] if len(args) == 2 else None
+
+if pid not in redcap_config.pids_to_tokens:
+  print >> sys.stderr, "ERROR: project id '%s' not a known project id.  Known project ids are: %s" % (pid, ", ".join(redcap_config.pids_to_tokens.keys()))
+  sys.exit(1)
+
+if input_filename and not os.path.isfile(input_filename):
+  print >> sys.stderr, "ERROR: '%s' is not a file" % (input_filename)
+  sys.exit(1)
+
+primary_key = DEFAULT_PRIMARY_KEY
+chunk = DEFAULT_CHUNK
+verbose = False
+
+for o, a in opts:
+  if o in ("-v", "--verbose"):
+    verbose = True
+  elif o in ("-k", "--key"):
+    primary_key = a
+  elif o in ("-c", "--chunk"):
+    try:
+      chunk = int(a)
+    except ValueError:
+      print >> sys.stderr, "ERROR:", a, "is not a valid integer for chunk size"
+      usage()
+      sys.exit(1) 
+
+if verbose:
+  print "LOG: pid =", pid
+  print "LOG: input_filename =", input_filename if input_filename else "reading piped input"
+  print "LOG: primary_key =", primary_key 
+  print "LOG: chunk =", chunk
+  print "LOG: verbose =", verbose 
+
+if input_filename:
+  with open(input_filename, 'rb') as input_file:
+    parse_csv(pid, input_file, primary_key, chunk, verbose)
+else:
+  parse_csv(pid, sys.stdin, primary_key, chunk, verbose)


### PR DESCRIPTION
This is the start of a set of Python scripts to interact with the RedCap API.

Included:

* An update method that uses the RedCap API to upload a list of field -> value dictionaries
* A script that can read a CSV formatted file (or input stream) that could be uploaded into RedCap via the RedCap website's import form, but instead will be uploaded using this module and the RedCap API