### PR TITLE
Backup a redcap project, data and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # redcap
 Scripts for interacting with RedCap via API
 
+## backup_redcap_project.py [options] pid > output.xml
+
+Exports the entire REDCap project as an XML file (metadata and data).
+
+If REDCap returns anything but a 200 RESPONSE_CODE an error is written to the standard error stream, and the standard out stream will be empty.
+
+From the REDCap documentation, "The entire project (all records, events, arms, instruments, fields, and project attributes) can be downloaded as a single
+XML file, which is in CDISC ODM format (ODM version 1.3.1). This XML file can be used to create a clone of the project (including its data, optionally) on this REDCap server
+or on another REDCap server (it can be uploaded on the Create New Project page)."
+
 ## upload_csv_to_redcap.py [options] pid input_filename
 
 Read CSV file or stdin made to be loaded into redcap via the import tool and update project using API.

--- a/backup_redcap_project.py
+++ b/backup_redcap_project.py
@@ -1,0 +1,52 @@
+# Backup a RedCap project
+#
+# Usage:
+#   backup_redcap_project.py [options] pid
+#     Options:
+#       -v, --verbose Turn on verbose logging
+#   e.g. backup_redcap_project.py -v 99 > redcap_project.xml
+#
+# Author: Manda Wilson
+
+import redcap
+import redcap_config
+import sys
+import getopt
+
+def usage():
+  print "Usage:"
+  print "  backup_redcap_project.py [options] pid"
+  print "    Options:"
+  print "      -v, --verbose Turn on verbose logging"
+  print "  e.g. backup_redcap_project.py -v 99 > redcap_project.xml"
+
+try:
+  opts, args = getopt.getopt(sys.argv[1:], "v", ["verbose"])
+except getopt.GetoptError as err:
+  # print help information and exit:
+  print str(err) # will print something like "option -a not recognized"
+  usage()
+  sys.exit(1)
+
+if len(args) < 1:
+  print >> sys.stderr, "ERROR: project id is required"
+  usage()
+  sys.exit(1)
+
+pid = args[0]
+
+if pid not in redcap_config.pids_to_tokens:
+  print >> sys.stderr, "ERROR: project id '%s' not a known project id.  Known project ids are: %s" % (pid, ", ".join(redcap_config.pids_to_tokens.keys()))
+  sys.exit(1)
+
+verbose = False
+
+for o, a in opts:
+  if o in ("-v", "--verbose"):
+    verbose = True
+
+if verbose:
+  print "LOG: pid =", pid
+  print "LOG: verbose =", verbose 
+
+print redcap.download_backup(pid, verbose=verbose)

--- a/redcap.py
+++ b/redcap.py
@@ -15,7 +15,8 @@ def update_records(pid, list_of_fields_to_values, overwrite="overwrite", return_
     of the format definition for the field."""
   buf = cStringIO.StringIO()
   json_data = '[' + ",".join([ '{' + ",".join(["\"%s\":\"%s\"" % (field, str(value).replace("\"", "\\\"")) for field, value in fields_to_values.iteritems()]) + '}' for fields_to_values in list_of_fields_to_values ]) + ']'
-  print "LOG:", json_data
+  if verbose:
+    print "LOG:", json_data
   data = {
     'token': redcap_config.pids_to_tokens[pid],
     'content': 'record',
@@ -37,3 +38,35 @@ def update_records(pid, list_of_fields_to_values, overwrite="overwrite", return_
   body = buf.getvalue()
   buf.close()
   return json.load(StringIO(body)) # returns count of updated records e.g. {"count": 1} or list of IDs that were updated
+
+def download_backup(pid, verbose=False):
+  """Export Entire Project as REDCap XML File (containing metadata & data).  
+    Raises RuntimeError if RESPONSE_CODE is not 200."""
+  buf = cStringIO.StringIO()
+  # exportFiles = true can make the export very large and may prevent it from completing if the project contains many files or very large files.
+  # tested exportFiles by uplading a file called 'test_upload.txt' containing 'testing' and this was included in the downloaded XML
+  # <ItemDataBase64Binary ItemOID="test" redcap:DocName="test_upload.txt" redcap:MimeType="text/plain"><![CDATA[dGVzdGluZwo=]]></ItemDataBase64Binary>
+  # using a base 63 decoder, 'dGVzdGluZwo=' became 'testing'
+  # returnMetadataOnly = 'false' doesn't seem to work, but false is the default, so I just removed it
+  data = {
+    'token': redcap_config.pids_to_tokens[pid],
+    'content': 'project_xml',
+    'returnFormat': 'jsoXn',
+    'exportSurveyFields': 'true',
+    'exportDataAccessGroups': 'true',
+    'exportFiles': 'true',
+  }
+  curl = pycurl.Curl()
+  curl.setopt(curl.URL, redcap_config.api_url)
+  curl.setopt(curl.HTTPPOST, data.items())
+  curl.setopt(curl.WRITEFUNCTION, buf.write)
+  #curl.setopt(pycurl.SSL_VERIFYPEER, 0)
+  #curl.setopt(pycurl.SSL_VERIFYHOST, 0)
+  curl.perform()
+  response_code = curl.getinfo(curl.RESPONSE_CODE)
+  curl.close()
+  body = buf.getvalue()
+  buf.close()
+  if response_code != 200:
+    raise RuntimeError("Response code '%d' returned expecting '200'.  Error is '%s'" % (response_code, body))
+  return body

--- a/upload_csv_to_redcap.py
+++ b/upload_csv_to_redcap.py
@@ -25,8 +25,7 @@ def update_redcap(expected_ids, pid, current_rows, overwrite="normal", return_co
   if verbose:
     print "LOG: updated:", updated
   if "error" in updated:
-    print >> sys.stderr, "ERROR: failed to update record(s).  Message is '%s'.  JSON is '%s'" % (updated["error"], row)
-    print >> sys.stderr, [row]
+    print >> sys.stderr, "ERROR: failed to update record(s).  Message is '%s'.  JSON is '%s'" % (updated["error"], updated)
     sys.exit()
 
   failed_to_update = expected_ids - set(updated)
@@ -67,7 +66,7 @@ except getopt.GetoptError as err:
   usage()
   sys.exit(1)
 
-if args < 1:
+if len(args) < 1:
   print >> sys.stderr, "ERROR: project id is required"
   usage()
   sys.exit(1)


### PR DESCRIPTION
We will use this to backup and version REDCap studies.

python backup_redcap_project.py [options] pid > output.xml

If nothing is written to standard error, and output.xml is not empty, then the next step is to check output.xml into git (a PHI approved instance of git) so that we have snapshots of the project.  Then if we ever need to revert the project, or set up "frozen" instances of it, we can.